### PR TITLE
[feat] Remove updateEventLog, deleteEventLog and add isTest param to addEventLog

### DIFF
--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/zaiclient.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/zaiclient.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71B57E95EF5FC55C493D73C873471A05"
+               BuildableName = "zaiclient.framework"
+               BlueprintName = "zaiclient"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71B57E95EF5FC55C493D73C873471A05"
+            BuildableName = "zaiclient.framework"
+            BlueprintName = "zaiclient"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -77,7 +77,7 @@ public func checkSuccessfulEventAdd(event: BaseEvent?, isTest: Bool = false, com
                             let ddbExpirationTime = Int(ddbResponse.items![0]["expiration_time"]?.n ?? "0") ?? 0
                             
                             if (isTest) {
-                                expect(ddbExpirationTime - ddbTimestamp).to(beGreaterThanOrEqualTo(60 * 60 * 23))
+                                expect(ddbExpirationTime - ddbTimestamp).to(beLessThanOrEqualTo(60 * 60 * 25))
                             } else {
                                 expect(ddbExpirationTime - ddbTimestamp).to(beGreaterThanOrEqualTo(60 * 60 * 24 * 364))
                             }
@@ -109,7 +109,7 @@ public func checkSuccessfulEventAdd(event: BaseEvent?, isTest: Bool = false, com
                                 
                                 if (isTest) {
                                     print(ddbExpirationTime - ddbTimestamp)
-                                    expect(ddbExpirationTime - ddbTimestamp).to(beGreaterThanOrEqualTo(60 * 60 * 23))
+                                    expect(ddbExpirationTime - ddbTimestamp).to(beLessThanOrEqualTo(60 * 60 * 25))
                                 } else {
                                     expect(ddbExpirationTime - ddbTimestamp).to(beGreaterThanOrEqualTo(60 * 60 * 24 * 364))
                                 }

--- a/Example/Tests/ZaiClientCollectorTests.swift
+++ b/Example/Tests/ZaiClientCollectorTests.swift
@@ -30,24 +30,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
                 
-                it("updateEventLog") {
-                    var flag = false
-                    let userId = generateUUID()
-                    let event = try? ProductDetailViewEvent(userId: userId, itemId: generateUUID())
-                    let newEvent = try? ProductDetailViewEvent(userId: userId, itemId: generateUUID(), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
+                it("addEventLog with isTest true") {
                     var flag = false
                     let e = try? ProductDetailViewEvent(userId: generateUUID(), itemId: generateUUID())
-                    checkSuccessfulEventDelete(event: e) {
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }
@@ -81,24 +67,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
                 
-                it("updateEventLog") {
+                it("addEventLog with isTest true") {
                     var flag = false
-                    let userId = generateUUID()
-                    let event = try? PageViewEvent(userId: userId, pageType: generatePageType())
-                    let newEvent = try? PageViewEvent(userId: userId, pageType: generatePageType(), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
-                    var flag = false
-                    let e = try? PageViewEvent(userId: generateUUID(), pageType: generatePageType())
-                    checkSuccessfulEventDelete(event: e) {
+                    let e = try? PageViewEvent(userId: generateUUID(), pageType: generateUUID())
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }
@@ -132,24 +104,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
                 
-                it("updateEventLog") {
-                    var flag = false
-                    let userId = generateUUID()
-                    let event = try? LikeEvent(userId: userId, itemId: generateUUID())
-                    let newEvent = try? LikeEvent(userId: userId, itemId: generateUUID(), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
+                it("addEventLog with isTest true") {
                     var flag = false
                     let e = try? LikeEvent(userId: generateUUID(), itemId: generateUUID())
-                    checkSuccessfulEventDelete(event: e) {
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }
@@ -182,25 +140,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     }
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
-                
-                it("updateEventLog") {
-                    var flag = false
-                    let userId = generateUUID()
-                    let event = try? CartaddEvent(userId: userId, itemId: generateUUID())
-                    let newEvent = try? CartaddEvent(userId: userId, itemId: generateUUID(), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
+                it("addEventLog with isTest true") {
                     var flag = false
                     let e = try? CartaddEvent(userId: generateUUID(), itemId: generateUUID())
-                    checkSuccessfulEventDelete(event: e) {
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }
@@ -233,25 +176,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     }
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
-                
-                it("updateEventLog") {
-                    var flag = false
-                    let userId = generateUUID()
-                    let event = try? RateEvent(userId: userId, itemId: generateUUID(), rating: generateRandomDouble(min: 0, max: 5))
-                    let newEvent = try? RateEvent(userId: userId, itemId: generateUUID(), rating: generateRandomDouble(min: 0, max: 5), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
+                it("addEventLog with isTest true") {
                     var flag = false
                     let e = try? RateEvent(userId: generateUUID(), itemId: generateUUID(), rating: generateRandomDouble(min: 0, max: 5))
-                    checkSuccessfulEventDelete(event: e) {
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }
@@ -284,25 +212,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     }
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
-                
-                it("updateEventLog") {
-                    var flag = false
-                    let userId = generateUUID()
-                    let event = try? SearchEvent(userId: userId, searchQuery: generateQuery())
-                    let newEvent = try? SearchEvent(userId: userId, searchQuery: generateQuery(), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
+                it("addEventLog with isTest true") {
                     var flag = false
                     let e = try? SearchEvent(userId: generateUUID(), searchQuery: generateQuery())
-                    checkSuccessfulEventDelete(event: e) {
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }
@@ -336,6 +249,17 @@ class ZaiClientCollectorSpec: QuickSpec {
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
                 
+                it("addEventLog with isTest true") {
+                    var flag = false
+                    let e = try? PurchaseEvent(userId: generateUUID(), itemId: generateUUID(), price: generateRandomInt(min: 0, max: 500000))
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
+                        (success, error) in if let _ = success {
+                            flag = true
+                        }
+                    }
+                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
+                }
+                
                 it("addBatchEventLog") {
                     var flag = false
                     let e = try? PurchaseEvent(userId: generateUUID(), itemIds: Array(repeating: generateUUID(), count: 10), prices: Array(repeating: generateRandomInt(min: 0, max: 500000), count: 10))
@@ -358,24 +282,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
                 
-                it("updateEventLog") {
+                it("addBatchEventLog with isTest true") {
                     var flag = false
-                    let userId = generateUUID()
-                    let event = try? PurchaseEvent(userId: userId, itemId: generateUUID(), price: generateRandomInt(min: 0, max: 500000))
-                    let newEvent = try? PurchaseEvent(userId: userId, itemId: generateUUID(), price: generateRandomInt(min: 0, max: 500000), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
-                    var flag = false
-                    let e = try? PurchaseEvent(userId: generateUUID(), itemId: generateUUID(), price: generateRandomInt(min: 0, max: 5000000))
-                    checkSuccessfulEventDelete(event: e) {
+                    let e = try? PurchaseEvent(userId: generateUUID(), itemIds: Array(repeating: generateUUID(), count: 10), prices: Array(repeating: generateRandomInt(min: 0, max: 500000), count: 10))
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }
@@ -409,6 +319,17 @@ class ZaiClientCollectorSpec: QuickSpec {
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
                 
+                it("addEventLog with isTest true") {
+                    var flag = false
+                    let e = try? CustomEvent(userId: generateUUID(), itemId: generateUUID(), eventType: "customEvent", eventValue: generateQuery())
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
+                        (success, error) in if let _ = success {
+                            flag = true
+                        }
+                    }
+                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
+                }
+                
                 it("addBatchEventLog") {
                     var flag = false
                     let e = try? CustomEvent(userId: generateUUID(), itemIds: Array(repeating: generateUUID(), count: 10), eventType: "customEvent", eventValues: Array(repeating: generateQuery(), count: 10))
@@ -431,25 +352,10 @@ class ZaiClientCollectorSpec: QuickSpec {
                     expect(flag).toEventually(equal(true), timeout: .seconds(10))
                 }
                 
-                it("updateEventLog") {
+                it("addBatchEventLog with isTest true") {
                     var flag = false
-                    let userId = generateUUID()
-                    let event = try? CustomEvent(userId: userId, itemId: generateUUID(), eventType: "customEvent", eventValue: generateUUID())
-                    let newEvent = try? CustomEvent(userId: userId, itemId: generateUUID(), eventType: "customEvent", eventValue: generateUUID(), timestamp: event!.timestamp)
-                    
-                    checkSuccessfulEventUpdate(event: event, newEvent: newEvent) {
-                        (success, error) in if let _ = success {
-                            flag = true
-                        }
-                    }
-                    expect(flag).toEventually(equal(true), timeout: .seconds(10))
-                }
-                
-                it("deleteEventLog") {
-                    var flag = false
-                    let e = try? CustomEvent(userId: generateUUID(), itemId: generateUUID(), eventType: "customEvent", eventValue: generateUUID())
-
-                    checkSuccessfulEventDelete(event: e) {
+                    let e = try? CustomEvent(userId: generateUUID(), itemIds: Array(repeating: generateUUID(), count: 10), eventType: "customEvent", eventValues: Array(repeating: generateQuery(), count: 10))
+                    checkSuccessfulEventAdd(event: e, isTest: true) {
                         (success, error) in if let _ = success {
                             flag = true
                         }

--- a/Example/zaiclient.xcodeproj/xcshareddata/xcschemes/zaiclient_Tests.xcscheme
+++ b/Example/zaiclient.xcodeproj/xcshareddata/xcschemes/zaiclient_Tests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "zaiclient_Tests.xctest"
+               BlueprintName = "zaiclient_Tests"
+               ReferencedContainer = "container:zaiclient.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/zaiclient/Classes/Request/BaseEvent.swift
+++ b/Sources/zaiclient/Classes/Request/BaseEvent.swift
@@ -3,7 +3,10 @@ import Foundation
 open class BaseEvent {
 
     public var timestamp: Double
-    private var payload: [Event]
+    private var userId: String
+    private var itemIds: [String]
+    private var superEventType: String
+    private var superEventValues: [String]
     
     init(userId: String, itemIds: [String], superEventType: String, superEventValues: [String], timestamp: Double) throws {
         // Input validation
@@ -24,28 +27,32 @@ open class BaseEvent {
             }
         }
         
-        var events: [Event] = []
-        
-        self.timestamp = timestamp
-        var tmpTimestamp = timestamp
-        
-        for (itemId, eventValue) in zip(itemIds, superEventValues) {
-            events.append(Event(userId: userId, itemId: itemId, timestamp: tmpTimestamp, eventType: superEventType, eventValue: String(eventValue.prefix(500))))
-            tmpTimestamp += Config.epsilon
-        }
-        
-        if events.count == 0 {
+        if itemIds.count == 0 {
             throw ZaiError.EmptyBatch
         }
-        
-        if events.count > Config.batchRequestCap {
+        if itemIds.count > Config.batchRequestCap {
             throw ZaiError.BatchSizeLimitExceeded
         }
         
-        payload = events
+        self.userId = userId
+        self.itemIds = itemIds
+        self.superEventType = superEventType
+        self.superEventValues = superEventValues
+        self.timestamp = timestamp
+        
     }
     
-    public func getPayload() -> [Event] {
-        return self.payload
+    public func getPayload(isTest: Bool = false) -> [Event] {
+        var events: [Event] = []
+
+        var tmpTimestamp = timestamp
+        
+        for (itemId, eventValue) in zip(itemIds, superEventValues) {
+            let timeToLive: Int? = (isTest) ? 60 * 60 * 24 : nil
+            events.append(Event(userId: userId, itemId: itemId, timestamp: tmpTimestamp, eventType: superEventType, eventValue: String(eventValue.prefix(500)), timeToLive: timeToLive))
+            tmpTimestamp += Config.epsilon
+        }
+        
+        return events
     }
 }

--- a/Sources/zaiclient/Classes/Request/Event.swift
+++ b/Sources/zaiclient/Classes/Request/Event.swift
@@ -6,6 +6,7 @@ public class Event: Encodable {
     public var timestamp: Double
     public var eventType: String
     public var eventValue: String
+    public var timeToLive: Int?
     
     enum CodingKeys: String, CodingKey {
             case userId = "user_id"
@@ -13,14 +14,16 @@ public class Event: Encodable {
             case timestamp = "timestamp"
             case eventType = "event_type"
             case eventValue = "event_value"
+            case timeToLive = "time_to_live"
     }
     
-    init(userId: String, itemId: String, timestamp: Double, eventType: String, eventValue: String) {
+    init(userId: String, itemId: String, timestamp: Double, eventType: String, eventValue: String, timeToLive: Int?) {
         self.userId = userId
         self.itemId = itemId
         self.timestamp = timestamp
         self.eventType = eventType
         self.eventValue = eventValue
+        self.timeToLive = timeToLive
     }
 }
 

--- a/Sources/zaiclient/Classes/ZaiClient.swift
+++ b/Sources/zaiclient/Classes/ZaiClient.swift
@@ -52,41 +52,16 @@ public class ZaiClient {
         }
     }
     
-    public func addEventLog(_ event: BaseEvent, completionHandler: @escaping (EventLoggerResponse?, ZaiError.ClientError?) -> () = { _,_  in }) {
+    public func addEventLog(_ event: BaseEvent, isTest: Bool = false, completionHandler: @escaping (EventLoggerResponse?, ZaiError.ClientError?) -> () = { _,_  in }) {
         let url = "\(self._eventsApiEndpoint)\(Config.eventsApiPath)"
         var zaiHeaders = generateZAiHeaders(zaiClientID: self._zaiClientID, zaiSecret: self._zaiSecret, path: Config.eventsApiPath)
         zaiHeaders.add(HTTPHeader(name: Config.zaiCallTypeHeader, value: Config.zaiCallType))
-        let payload = event.getPayload()
+        let payload = event.getPayload(isTest: isTest)
         
         if payload.count == 1 {
             sendRequest(EventLoggerResponse.self, method: .post, url: url, payload: payload[0], headers: zaiHeaders, completionHandler: completionHandler)
         } else {
             sendRequest(EventLoggerResponse.self, method: .post, url: url, payload: payload, headers: zaiHeaders, completionHandler: completionHandler)
-        }
-    }
-    
-    public func updateEventLog(_ event: BaseEvent, completionHandler: @escaping (EventLoggerResponse?, ZaiError.ClientError?) -> () = { _,_  in }) throws {
-        let url = "\(self._eventsApiEndpoint)\(Config.eventsApiPath)"
-        var zaiHeaders = generateZAiHeaders(zaiClientID: self._zaiClientID, zaiSecret: self._zaiSecret, path: Config.eventsApiPath)
-        zaiHeaders.add(HTTPHeader(name: Config.zaiCallTypeHeader, value: Config.zaiCallType))
-        let payload = event.getPayload()
-        
-        if payload.count > 1 {
-            throw ZaiError.BatchUpdateForbidden
-        }
-        sendRequest(EventLoggerResponse.self, method: .put, url: url, payload: payload[0], headers: zaiHeaders, completionHandler: completionHandler)
-    }
-
-    public func deleteEventLog(_ event: BaseEvent, completionHandler: @escaping (EventLoggerResponse?, ZaiError.ClientError?) -> () = { _,_  in }) {
-        let url = "\(self._eventsApiEndpoint)\(Config.eventsApiPath)"
-        var zaiHeaders = generateZAiHeaders(zaiClientID: self._zaiClientID, zaiSecret: self._zaiSecret, path: Config.eventsApiPath)
-        zaiHeaders.add(HTTPHeader(name: Config.zaiCallTypeHeader, value: Config.zaiCallType))
-        let payload = event.getPayload()
-
-        if payload.count == 1 {
-            sendRequest(EventLoggerResponse.self, method: .delete, url: url, payload: payload[0], headers: zaiHeaders, completionHandler: completionHandler)
-        } else {
-            sendRequest(EventLoggerResponse.self, method: .delete, url: url, payload: payload, headers: zaiHeaders, completionHandler: completionHandler)
         }
     }
 

--- a/zaiclient.podspec
+++ b/zaiclient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'zaiclient'
-  s.version          = '0.2.1'
+  s.version          = '1.0.0'
   s.summary          = 'REST client SDK that allows you to easily use Z.Ai API in Swift environment.'
 
   s.homepage         = 'https://github.com/zaikorea/zaiclient-swift'


### PR DESCRIPTION
• updateEventLog, deleteEventLog 함수를 삭제하고 관련 Test code 또한 삭제하였습니다.
• addEventLog 함수에 isTest parameter를 추가하여 isTest가 true로 들어오는 경우에는 collector api request body에 time_to_live를 60 * 60 * 24 (24시간)으로 설정하여 POST 요청을 보내도록 하였습니다.
• 아직 배포는 안할거지만 미리 버전 올려두었습니다. (version 0.2.1 -> 1.0.0)

• isTest parameter관련 사용 예시는 아래와 같습니다.  
`zaiClient.addEventLog(productDetailViewEvent, isTest: true)`